### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/Centre-Registry-config/dump_sqlite.py
+++ b/Centre-Registry-config/dump_sqlite.py
@@ -3,4 +3,4 @@ from sqlite3 import connect
 
 with open('dump.sql', 'w') as f:
     for line in connect('Centre_Registry.sqlite').iterdump():
-        f.write('%s\n' % line)
+        f.write('{0!s}\n'.format(line))


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:sanmai-NL:Centre-Registry?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:sanmai-NL:Centre-Registry?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)